### PR TITLE
ci: Build docs on PRs with docs changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+  pull_request:
+    paths:
+      - "docs/**"
   workflow_dispatch:
 
 permissions:
@@ -27,6 +30,7 @@ jobs:
         working-directory: docs
 
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Trigger docs workflow on PRs that change `docs/**` to catch build failures early
- Only deploy to gh-pages on push to main, not on PRs